### PR TITLE
fixed connection method

### DIFF
--- a/lua/sqlua/connection.lua
+++ b/lua/sqlua/connection.lua
@@ -280,7 +280,7 @@ end
 ---@return nil
 ---Adds the given url + name to the connections.json file
 Connections.add = function(url, name)
-  local file = Connections:read()
+  local file = Connections.read()
   table.insert(file, {url = url, name = name})
   vim.fn.mkdir(ROOT_DIR..'/name', "p")
   Connections.write(file)


### PR DESCRIPTION
Connections object method was changed from `Connections:read()` to `Connections.read()`, but the corresponding call in `Connections.add()` was still using the self version of `:`. Still working in 0.9.0 release, but changed nonetheless.