### PR TITLE
Feature/sidebar hotkeys

### DIFF
--- a/lua/sqlua/connectors/base.lua
+++ b/lua/sqlua/connectors/base.lua
@@ -367,7 +367,6 @@ function Connection:executeUv(query_type, query_data, --[[optional]] db)
     if type(query_data) ~= 'table' then
         query_data = {query_data}
     end
-    P(query_data)
 
     local uv = vim.uv
 

--- a/lua/sqlua/connectors/base.lua
+++ b/lua/sqlua/connectors/base.lua
@@ -336,7 +336,7 @@ function Connection:query(query, data)
     local ui = require("sqlua.ui")
     table.insert(ui.queries, q)
 
-    if ui.buffers.results ~= nil then
+    if ui.buffers.results ~= nil and ui.windows.results ~= nil then
         setSidebarModifiable(ui.buffers.results, true)
         vim.api.nvim_buf_set_lines(ui.buffers.results, 0, -1, false, data)
         vim.api.nvim_win_set_cursor(ui.windows.results, {1, 0})
@@ -428,21 +428,24 @@ function Connection:executeUv(query_type, query_data, --[[optional]] db)
 
     uv.shutdown(stdin, vim.schedule_wrap(function()
         if query_type == "query" then
+            local win = nil;
             setSidebarModifiable(ui.buffers.results, true)
-            if ui.buffers.results ~= nil then
+            if ui.buffers.results ~= nil and ui.windows.results ~= nil then
+                win = ui.windows.results
                 vim.api.nvim_buf_set_lines(
                     ui.buffers.results, 0, -1, false, {})
             else
-                ui:createResultsPane({})
+                win, _ = ui:createResultsPane({})
             end
+            print(ui.windows.results, ui.buffers.results, win)
             if not ui.windows.query_float then
-                local w = vim.api.nvim_win_get_width(ui.windows.results)
-                local h = vim.api.nvim_win_get_height(ui.windows.results)
+                local w = vim.api.nvim_win_get_width(win)
+                local h = vim.api.nvim_win_get_height(win)
                 local b = vim.api.nvim_create_buf(false, true)
                 ui.buffers.query_float = b
                 local fwin = vim.api.nvim_open_win(b, false, {
                     relative='win',
-                    win=ui.windows.results,
+                    win=win,
                     row=h/2 - 1,
                     col=w/2 - math.floor(w/3) / 2,
                     width=math.floor(w/3), height=1,

--- a/lua/sqlua/ui.lua
+++ b/lua/sqlua/ui.lua
@@ -156,33 +156,33 @@ local function toggleExpanded(table, search)
 	end
 end
 
----@param buf buffer
----@param srow integer
----@param text string
----@param sep string
+---@param buf buffer sidebar buffer
+---@param srow integer starting row to indent
+---@param sep string length of whitespace indent
+---@param text string text to print
 ---@return integer
-local function printSidebarExpanded(buf, srow, text, sep)
+local function printSidebarExpanded(buf, srow, sep, text)
 	vim.api.nvim_buf_set_lines(buf, srow, srow, false, {
         sep..UI_ICONS.expanded.." "..text
     })
 	return srow + 1
 end
 
----@param buf buffer
----@param srow integer
----@param text string
----@param sep string
+---@param buf buffer sidebar buffer
+---@param srow integer starting row to indent
+---@param sep string length of whitespace indent
+---@param text string text to print
 ---@return integer
-local function printSidebarCollapsed(buf, srow, text, sep)
+local function printSidebarCollapsed(buf, srow, sep, text)
 	vim.api.nvim_buf_set_lines(buf, srow, srow, false, {
         sep..UI_ICONS.collapsed.." "..text
     })
 	return srow + 1
 end
 
----@param buf buffer
----@param srow integer
----@param text string
+---@param buf buffer sidebar buffer
+---@param srow integer starting row to indent
+---@param text string text to print
 ---@return integer
 local function printSidebarEmpty(buf, srow, text)
     print(text)
@@ -258,6 +258,9 @@ local function createTableStatement(type, tbl, schema, database, db, dbms)
 end
 
 
+---@param val string
+---@return number
+---returns a numeric count of indent level based on leading whitespace
 local function countIndentWhitespace(val)
     local current_indent = 0
     for i = 1, #val do
@@ -360,6 +363,7 @@ local sidebarFind = {
         end
         return db, num
     end,
+    ---@param num integer sidebar starting line
     first_collapsible = function(num)
         local line = nil
         while true do
@@ -381,6 +385,7 @@ local sidebarFind = {
         end
         return line, num
     end,
+    ---@param num integer sidebar starting line
     first_parent = function(num)
         local line = nil
         local initial_indent = nil
@@ -409,113 +414,114 @@ local sidebarFind = {
 }
 
 
+---The primary way of refreshing the sidebar to account for any changes
 function UI:refreshSidebar()
-	---@param buf buffer
-	---@param srow integer
-	---@param schema Schema
-	---@param sep string
+    ---@param buf buffer sidebar buffer
+    ---@param srow integer starting row to indent
+    ---@param sep string length of whitespace indent
+    ---@param schema Schema schema name
 	---@return integer srow
-	local function refreshTables(buf, srow, schema, sep)
+	local function refreshTables(buf, srow, sep, schema)
 		local queries = require("sqlua/queries." .. schema.dbms)
 		local statements = queries.ddl
 
         local nt = schema.num_tables or 0
 		local text = UI_ICONS.tables.." Tables ("..nt..")"
 		if schema.tables_expanded then
-			srow = printSidebarExpanded(buf, srow, text, sep)
+			srow = printSidebarExpanded(buf, srow, sep, text)
             for table, _ in Utils.pairsByKeys(schema.tables) do
                 local txt = UI_ICONS.table.." "..table
                 if schema.tables[table].expanded then
-                    srow = printSidebarExpanded(buf, srow, txt, sep.."  ")
+                    srow = printSidebarExpanded(buf, srow, sep.."  ", txt)
                     for _, stmt in Utils.pairsByKeys(statements) do
                         txt = UI_ICONS.table_stmt.." "..stmt
                         srow = printSidebarEmpty(buf, srow, sep.."      "..txt)
                     end
                 else
-                    srow = printSidebarCollapsed(buf, srow, txt, sep.."  ")
+                    srow = printSidebarCollapsed(buf, srow, sep.."  ", txt)
                 end
             end
         else
-			srow = printSidebarCollapsed(buf, srow, text, sep)
+			srow = printSidebarCollapsed(buf, srow, sep, text)
         end
 		return srow
 	end
-	---@param buf buffer
-	---@param srow integer
-	---@param schema Schema
-	---@param sep string
+    ---@param buf buffer sidebar buffer
+    ---@param srow integer starting row to indent
+    ---@param sep string length of whitespace indent
+    ---@param schema Schema schema name
 	---@return integer srow
-	local function refreshViews(buf, srow, schema, sep)
+	local function refreshViews(buf, srow, sep, schema)
         local nv = schema.num_views or 0
 		local v_text = UI_ICONS.views.." Views ("..nv..")"
 		if schema.views_expanded then
-			srow = printSidebarExpanded(buf, srow, v_text, sep)
+			srow = printSidebarExpanded(buf, srow, sep, v_text)
             for view, _ in Utils.pairsByKeys(schema.views) do
                 local text = UI_ICONS.view.." "..view
                 srow = printSidebarEmpty(buf, srow, sep.."    "..text)
             end
         else
-			srow = printSidebarCollapsed(buf, srow, v_text, sep)
+			srow = printSidebarCollapsed(buf, srow, sep, v_text)
         end
 		return srow
 	end
-	---@param buf buffer
-	---@param srow integer
-	---@param schema Schema
-	---@param sep string
+    ---@param buf buffer sidebar buffer
+    ---@param srow integer starting row to indent
+    ---@param schema Schema schema name
+    ---@param sep string length of whitespace indent
 	---@return integer srow
-	local function refreshFunctions(buf, srow, schema, sep)
+	local function refreshFunctions(buf, srow, sep, schema)
         local nf = schema.num_functions or 0
 		local f_text = UI_ICONS.functions.." Functions (" ..nf..")"
 		if schema.functions_expanded then
-			srow = printSidebarExpanded(buf, srow, f_text, sep)
+			srow = printSidebarExpanded(buf, srow, sep, f_text)
             for fn, _ in Utils.pairsByKeys(schema.functions) do
                 local text = UI_ICONS._function.." "..fn
                 srow = printSidebarEmpty(buf, srow, sep.."    "..text)
             end
         else
-			srow = printSidebarCollapsed(buf, srow, f_text, sep)
+			srow = printSidebarCollapsed(buf, srow, sep, f_text)
         end
 		return srow
 	end
-	---@param buf buffer
-	---@param srow integer
-	---@param schema Schema
-	---@param sep string
+    ---@param buf buffer sidebar buffer
+    ---@param srow integer starting row to indent
+    ---@param sep string length of whitespace indent
+    ---@param schema Schema schema name
 	---@return integer srow
-	local function refreshProcedures(buf, srow, schema, sep)
+	local function refreshProcedures(buf, srow, sep, schema)
         local ns = schema.num_procedures or 0
 		local p_text = UI_ICONS.procedures.." Procedures ("..ns..")"
 		if schema.procedures_expanded then
-			srow = printSidebarExpanded(buf, srow, p_text, sep)
+			srow = printSidebarExpanded(buf, srow, sep, p_text)
             for fn, _ in Utils.pairsByKeys(schema.procedures) do
                 local text = UI_ICONS.procedure.." "..fn
                 srow = printSidebarEmpty(buf, srow, sep.."    "..text)
             end
         else
-			srow = printSidebarCollapsed(buf, srow, p_text, sep)
+			srow = printSidebarCollapsed(buf, srow, sep, p_text)
         end
 		return srow
 	end
-	---@param buf buffer
-	---@param file table
-	---@param srow integer
-	---@param sep string
+    ---@param buf buffer sidebar buffer
+    ---@param srow integer starting row to indent
+    ---@param sep string length of whitespace indent
+    ---@param file table file name
 	---@return integer srow
-	local function refreshSavedQueries(buf, file, srow, sep)
+	local function refreshSavedQueries(buf, srow, sep, file)
         if file.isdir then
             local text = UI_ICONS.folder.. " " .. file.name
             if file.expanded then
-                srow = printSidebarExpanded(buf, srow, text, sep)
+                srow = printSidebarExpanded(buf, srow, sep, text)
                 if next(file.files) ~= nil then
                     for _, f in Utils.pairsByKeys(file.files) do
                         srow = refreshSavedQueries(
-                            buf, f, srow, sep .. "  "
+                            buf, srow, sep .. "  ", f
                         )
                     end
                 end
             else
-                srow = printSidebarCollapsed(buf, srow, text, sep)
+                srow = printSidebarCollapsed(buf, srow, sep, text)
             end
         else
             local text = UI_ICONS.file.. " " .. file.name
@@ -523,34 +529,36 @@ function UI:refreshSidebar()
         end
 		return srow
 	end
-	---@param buf buffer
-	---@param db string
-	---@param srow integer
+    ---@param buf buffer sidebar buffer
+    ---@param srow integer starting row to indent
+    ---@param sep string length of whitespace indent
+    ---@param db string db name
 	---@return integer srow
-	local function refreshSchema(buf, db, srow, sep)
+	local function refreshSchema(buf, srow, sep, db)
         local s = self.dbs[db].schema
 		for schema, _ in Utils.pairsByKeys(s) do
 			local text = UI_ICONS.schema.." "..schema
             if type(s[schema]) == "table" then
                 if s[schema].expanded then
-					srow = printSidebarExpanded(buf, srow, text, sep)
+					srow = printSidebarExpanded(buf, srow, sep, text)
                     local ns = sep .. "  "
-					srow = refreshTables(buf, srow, s[schema], ns)
-					srow = refreshViews(buf, srow, s[schema], ns)
-					srow = refreshFunctions(buf, srow, s[schema], ns)
-					srow = refreshProcedures(buf, srow, s[schema], ns)
+					srow = refreshTables(buf, srow, ns, s[schema])
+					srow = refreshViews(buf, srow, ns, s[schema])
+					srow = refreshFunctions(buf, srow, ns, s[schema])
+					srow = refreshProcedures(buf, srow, ns, s[schema])
                 else
-                    srow = printSidebarCollapsed(buf, srow, text, sep)
+                    srow = printSidebarCollapsed(buf, srow, sep, text)
 				end
 			end
 		end
 		return srow
 	end
-	---@param buf buffer
-	---@param db string
-	---@param srow integer
+    ---@param buf buffer sidebar buffer
+    ---@param srow integer starting row to indent
+    ---@param sep string length of whitespace indent
+    ---@param db string db name
 	---@return integer srow
-	local function refreshSnowflakeDatabases(buf, db, srow, sep)
+	local function refreshSnowflakeDatabases(buf, srow, sep, db)
         local s = self.dbs[db].schema
         if not s.databases_loaded then
             srow = printSidebarEmpty(buf, srow, sep.."  󰑐 Loading Databases...")
@@ -559,7 +567,7 @@ function UI:refreshSidebar()
 			local text = UI_ICONS.db2.." "..sfdb
             if type(s[sfdb]) == "table" then
                 if s[sfdb].expanded then
-                    srow = printSidebarExpanded(buf, srow, text, sep)
+                    srow = printSidebarExpanded(buf, srow, sep, text)
                     local sep2 = sep .. "  "
                     local sf = self.dbs[db].schema[sfdb]
                     if not s[sfdb].schemata_loaded then
@@ -569,49 +577,49 @@ function UI:refreshSidebar()
                         local text2 = UI_ICONS.schema.." "..schema
                         if type(sf.schema[schema]) == "table" then
                             if sf.schema[schema].expanded then
-                                srow = printSidebarExpanded(buf, srow, text2, sep2)
+                                srow = printSidebarExpanded(buf, srow, sep2, text2)
                                 if not sf.schema[schema].schemas_loaded then
                                     srow = printSidebarEmpty(buf, srow, sep.."  󰑐 Loading Schema...")
                                 end
                                 local ns = sep2 .. "  "
-                                srow = refreshTables(buf, srow, sf.schema[schema], ns)
-                                srow = refreshViews(buf, srow, sf.schema[schema], ns)
-                                srow = refreshFunctions(buf, srow, sf.schema[schema], ns)
-                                srow = refreshProcedures(buf, srow, sf.schema[schema], ns)
+                                srow = refreshTables(buf, srow, ns, sf.schema[schema])
+                                srow = refreshViews(buf, srow, ns, sf.schema[schema])
+                                srow = refreshFunctions(buf, srow, ns, sf.schema[schema])
+                                srow = refreshProcedures(buf, srow, ns, sf.schema[schema])
                             else
-                                srow = printSidebarCollapsed(buf, srow, text2, sep2)
+                                srow = printSidebarCollapsed(buf, srow, sep2, text2)
                             end
                         end
                     end
                 else
-                    srow = printSidebarCollapsed(buf, srow, text, sep)
+                    srow = printSidebarCollapsed(buf, srow, sep, text)
 				end
 			end
 		end
 		return srow
 	end
-	---@param buf buffer
-	---@param db string
-	---@param srow integer
-	local function refreshDatabase(buf, db, srow)
+    ---@param buf buffer sidebar buffer
+    ---@param srow integer starting row to indent
+    ---@param db string db name
+	local function refreshDatabase(buf, srow, db)
 		local sep = "   "
 
 		local queries_text = UI_ICONS.folder.. " " .. "Queries"
 		if self.dbs[db].files_expanded then
-			srow = printSidebarExpanded(buf, srow, queries_text, sep)
+			srow = printSidebarExpanded(buf, srow, sep, queries_text)
             for _, file in Utils.pairsByKeys(self.dbs[db].files.files) do
                 srow = refreshSavedQueries(
-                    buf, file, srow, sep .. "  "
+                    buf, srow, sep .. "  ", file
                 )
             end
         else
-			srow = printSidebarCollapsed(buf, srow, queries_text, sep)
+			srow = printSidebarCollapsed(buf, srow, sep, queries_text)
         end
 
         if db == "snowflake" then
-            srow = refreshSnowflakeDatabases(buf, db, srow, sep)
+            srow = refreshSnowflakeDatabases(buf, srow, sep, db)
         else
-            srow = refreshSchema(buf, db, srow, sep)
+            srow = refreshSchema(buf, srow, sep, db)
         end
 
 		return srow
@@ -671,7 +679,7 @@ function UI:refreshSidebar()
     local buffers_text = UI_ICONS.schemas.. " " .. "Buffers"
     buffers_text = buffers_text.." ("..#self.buffers.editors..")"
     if self.buffers_expanded then
-        srow = printSidebarExpanded(buf, srow, buffers_text, sep)
+        srow = printSidebarExpanded(buf, srow, sep, buffers_text)
         for _, ebuf in Utils.pairsByKeys(self.buffers.editors) do
             local editor_name = vim.api.nvim_buf_get_name(ebuf)
             local split = Utils.splitString(editor_name, Utils.sep)
@@ -679,7 +687,7 @@ function UI:refreshSidebar()
             srow = printSidebarEmpty(buf, srow, text)
         end
     else
-        srow = printSidebarCollapsed(buf, srow, buffers_text, sep)
+        srow = printSidebarCollapsed(buf, srow, sep, buffers_text)
     end
     srow = srow + 1
 
@@ -696,21 +704,21 @@ function UI:refreshSidebar()
             local text = UI_ICONS.db.." "..db.." (".. ns ..")"
             if self.dbs[db].expanded then
                 db_rows[db] = srow - 1
-                printSidebarExpanded(buf, srow - 1, text, sep)
-                srow = refreshDatabase(buf, db, srow)
+                printSidebarExpanded(buf, srow - 1, sep, text)
+                srow = refreshDatabase(buf, srow, db)
             else
                 db_rows[db] = srow - 1
-                printSidebarCollapsed(buf, srow - 1, text, sep)
+                printSidebarCollapsed(buf, srow - 1, sep, text)
             end
         else
             local text = UI_ICONS.db.." "..db
             if self.dbs[db].loading then
                 db_rows[db] = srow - 1
-                printSidebarExpanded(buf, srow - 1, text, sep)
+                printSidebarExpanded(buf, srow - 1, sep, text)
                 srow = printSidebarEmpty(buf, srow, sep.."  󰑐 Loading ...")
             else
                 db_rows[db] = srow - 1
-                printSidebarCollapsed(buf, srow - 1, text, sep)
+                printSidebarCollapsed(buf, srow - 1, sep, text)
             end
         end
         if db == self.active_db then
@@ -732,7 +740,7 @@ function UI:refreshSidebar()
     local dbout_text = UI_ICONS.results .. " " .. "Results ("
         .. #self.queries..")"
     if self.results_expanded then
-        srow = printSidebarExpanded(buf, srow, dbout_text, sep)
+        srow = printSidebarExpanded(buf, srow, sep, dbout_text)
         local query_results = {}
         for i, tbl in ipairs(self.queries) do
             local text = sep.."    "..UI_ICONS.dbout.." "..tostring(i)
@@ -743,7 +751,7 @@ function UI:refreshSidebar()
             srow = printSidebarEmpty(buf, srow, q:gsub("[\n\r\t]", ' '))
         end
     else
-        srow = printSidebarCollapsed(buf, srow, dbout_text, sep)
+        srow = printSidebarCollapsed(buf, srow, sep, dbout_text)
     end
 
 	if not pcall(function()
@@ -833,6 +841,9 @@ local function getDatabaseAndSchema(cursorPos)
 end
 
 
+---@param num integer the row position
+---@param val string the exact name including whitespace
+---@param sub_val string the cleaned name without icons
 local function toggleSelectionUnderCursor(num, val, sub_val)
     if sub_val == "Buffers" then
         UI.buffers_expanded = not UI.buffers_expanded
@@ -946,6 +957,7 @@ local function getValueUnderCursor()
 end
 
 ---@return nil
+---primary function to initially create the sidebar
 local function createSidebar()
 	local win = UI.windows.sidebar
 	local buf = vim.api.nvim_create_buf(false, true)
@@ -1445,6 +1457,7 @@ function UI:setup(config)
     vim.api.nvim_buf_delete(1, {})
 end
 
+---performs vim syntax highlighting on results pane
 function UI.highlightResultsPane()
     local previous_buf = vim.api.nvim_get_current_buf()
     vim.api.nvim_set_current_buf(UI.buffers.sidebar)

--- a/lua/sqlua/ui.lua
+++ b/lua/sqlua/ui.lua
@@ -1056,7 +1056,6 @@ local function createSidebar()
             if not is_folder and not is_file and not is_dbout then
                 return
             end
-            P(UI.dbs[db].files)
             if is_folder or is_file then
                 text = text:gsub("%s+", "")
                 text = text:gsub(ICONS_SUB, "")

--- a/lua/sqlua/ui.lua
+++ b/lua/sqlua/ui.lua
@@ -185,6 +185,7 @@ end
 ---@param text string
 ---@return integer
 local function printSidebarEmpty(buf, srow, text)
+    print(text)
 	vim.api.nvim_buf_set_lines(buf, srow, srow, false, { text })
 	return srow + 1
 end
@@ -739,7 +740,7 @@ function UI:refreshSidebar()
             table.insert(query_results, text.." ("..stmt..")")
         end
         for _, q in ipairs(Utils.reverse(query_results)) do
-            srow = printSidebarEmpty(buf, srow, q)
+            srow = printSidebarEmpty(buf, srow, q:gsub("[\n\r\t]", ' '))
         end
     else
         srow = printSidebarCollapsed(buf, srow, dbout_text, sep)
@@ -1209,6 +1210,7 @@ local function createSidebar()
 			end
 
             local val, sub_val = getValueUnderCursor()
+            print(sub_val)
 
 			local is_collapsed, _ = string.find(val, UI_ICONS.collapsed)
 			local is_expanded, _ = string.find(val, UI_ICONS.expanded)

--- a/lua/sqlua/ui.lua
+++ b/lua/sqlua/ui.lua
@@ -1229,11 +1229,12 @@ local function createSidebar()
 			if is_collapsed or is_expanded then
                 toggleSelectionUnderCursor(num, val, sub_val)
 			else
-                local db, schema = getDatabaseAndSchema(num)
-                local queries = require("sqlua.queries."..UI.dbs[db].dbms)
-				if string.find(val, UI_ICONS.file) then
-					local file = val:gsub(ICONS_SUB, "")
-					openFileInEditor(db, file)
+                if string.find(val, UI_ICONS.new_query) then
+                    local buffer = createEditor(UI.windows.editors[1])
+                    UI:refreshSidebar()
+                    vim.api.nvim_set_current_win(UI.windows.editors[1])
+                    vim.api.nvim_set_current_buf(buffer)
+                    return
                 elseif string.find(val, UI_ICONS.buffers) then
 					local bufname = val:gsub(ICONS_SUB, "")
                     for _, ebuf in pairs(UI.buffers.editors) do
@@ -1245,11 +1246,13 @@ local function createSidebar()
                             vim.api.nvim_set_current_win(ewin)
                         end
                     end
-                elseif string.find(val, UI_ICONS.new_query) then
-                    local buffer = createEditor(UI.windows.editors[1])
-                    UI:refreshSidebar()
-                    vim.api.nvim_set_current_win(UI.windows.editors[1])
-                    vim.api.nvim_set_current_buf(buffer)
+                    return
+                end
+                local db, schema = getDatabaseAndSchema(num)
+                local queries = require("sqlua.queries."..UI.dbs[db].dbms)
+				if string.find(val, UI_ICONS.file) then
+					local file = val:gsub(ICONS_SUB, "")
+					openFileInEditor(db, file)
                 elseif string.find(val, UI_ICONS.dbout) then
                     local rbuf= UI.buffers.results
                     if rbuf == nil then

--- a/lua/sqlua/ui.lua
+++ b/lua/sqlua/ui.lua
@@ -1445,6 +1445,8 @@ function UI:setup(config)
 		callback = function(ev)
             if ev.file == tostring(UI.windows.results) then
                 UI.windows.results = nil
+            elseif ev.file == tostring(UI.windows.sidebar) then
+                UI.windows.sidebar = nil
             end
 		end,
 	})

--- a/lua/sqlua/ui.lua
+++ b/lua/sqlua/ui.lua
@@ -41,6 +41,7 @@ local Windows = {
 local UI = {
 	initial_layout_loaded = false,
 	help_toggled = false,
+    help_length = 0,
 	sidebar_ns = 0,
     buffers_expanded = false,
 	active_db = "",
@@ -639,6 +640,7 @@ function UI:refreshSidebar()
         " <leader>sf - focus sidebar",
         " "..self.options.keybinds.execute_query.." - run query",
     }
+    UI.help_length = #helpTextTable + 2
 
 	setSidebarModifiable(buf, true)
 	vim.api.nvim_buf_set_lines(self.buffers.sidebar, 0, -1, false, {})
@@ -648,7 +650,7 @@ function UI:refreshSidebar()
         vim.cmd("syn match SQLuaHelpText /\\(- \\).*/")
         vim.api.nvim_buf_set_lines(buf, 0, 0, false, helpTextTable)
         vim.cmd("syn match SQLuaHelpText /^$/")
-        srow = srow + #helpTextTable
+        srow = srow + #helpTextTable - 1
         vim.api.nvim_buf_add_highlight(
             self.buffers.sidebar, self.sidebar_ns, "Comment", 0, 0, winwidth
         )
@@ -1202,6 +1204,7 @@ local function createSidebar()
 			if num == num_lines then
 				local cursorCol = cursorPos[2]
 				local newpos = { num - 1, cursorCol }
+                UI.last_cursor_position.sidebar = cursorPos
 				vim.api.nvim_win_set_cursor(UI.windows.sidebar, newpos)
 			end
 
@@ -1297,7 +1300,13 @@ local function createSidebar()
 				end
 			end
             if vim.api.nvim_get_current_buf() == UI.buffers.sidebar then
-                vim.api.nvim_win_set_cursor(0, UI.last_cursor_position.sidebar)
+                if UI.help_toggled then
+                    local pos = UI.last_cursor_position.sidebar
+                    pos[1] = pos[1] - UI.help_length + 2
+                    vim.api.nvim_win_set_cursor(0, UI.last_cursor_position.sidebar)
+                else
+                    vim.api.nvim_win_set_cursor(0, UI.last_cursor_position.sidebar)
+                end
             end
 
 			highlightSidebarNumbers()

--- a/lua/sqlua/ui.lua
+++ b/lua/sqlua/ui.lua
@@ -632,6 +632,8 @@ function UI:refreshSidebar()
         string.format("%+" .. winwidth / 2 - (hl) .. "s%s", "", helptext),
         " a - add a file in the select dir",
         " d - delete the select file",
+        " o - fold the current node",
+        " O - fold to first collapsible parent",
         " "..self.options.keybinds.activate_db.." - set the active db",
         " <leader>st - toggle sidebar",
         " <leader>sf - focus sidebar",

--- a/lua/sqlua/utils.lua
+++ b/lua/sqlua/utils.lua
@@ -175,4 +175,16 @@ M.pairsByKeys = function(t, f)
 	return iter
 end
 
+---@param name string the buffer name to search for
+---@return integer | nil buf_id the buffer id
+M.getBufferByName = function(name)
+    local result = vim.api.nvim_list_bufs()
+    for _, buf in pairs(result) do
+        if vim.api.nvim_buf_get_name(buf):match(name) then
+            return buf
+        end
+    end
+    return nil
+end
+
 return M


### PR DESCRIPTION
- feat: added 2 new hotkeys to quickly collapse file tree cursor is inside:
  - `o` - similar to CR but also folds parent if over an item with no collapsibility
  - `O` - close fold up to direct parent regardless of collapsibility
should probably make these modifiable in the future (as with all hotkeys) 
- fix: allow reopening results window if previously closed and needing to be called
- fix: allow reopen sidebar with hotkey after closed
- chore: docs and reordering of `refreshSideBar` param ordering