### PR TITLE
added is_valid check for buf delete in UI setup

### DIFF
--- a/lua/sqlua/ui.lua
+++ b/lua/sqlua/ui.lua
@@ -1475,7 +1475,9 @@ function UI:setup(config)
 
 	createEditor(editor_win)
 	createSidebar()
-    vim.api.nvim_buf_delete(1, {})
+    if vim.api.nvim_buf_is_valid(1) then
+        vim.api.nvim_buf_delete(1, {})
+    end
 end
 
 ---performs vim syntax highlighting on results pane


### PR DESCRIPTION
Attempts to fix `invalid_buffer id: 1` on MacOS when deleting the [No Name] buffer in `UI:setup()` brought up in #23 