### PR TITLE
Update README.md: Neovim version required 0.10.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ alias nvsql="nvim '+SQLua'"
 ```
 
 ## Setup
+### Note: sqlua.nvim required Neovim 0.10.0+
 
 To use, require the setup:
 `:lua require('sqlua').setup(opts)`


### PR DESCRIPTION
`vim.ux`  required Neovim 0.10.0+