### PR TITLE
Make SQLuaEdit nvim cmd for Lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently supported DBMS:
 {
     'xemptuous/sqlua.nvim',
     lazy = true,
-    cmd = 'SQLua',
+    cmd = { 'SQLua', 'SQLuaEdit' },
     config = function() require('sqlua').setup() end
 }
 ```


### PR DESCRIPTION
Current SQLuaEdit cmd  in Lazy may be run only inside SQLua plugin i.e. after call `:SQLua` cmd.
This will enable  to call this function inside nvim itself