### PR TITLE
Execute query in insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ You can override the default settings by feeding the table as a table to the set
     load_connections_on_start = false,
     keybinds = {
         execute_query = "<leader>r",
-        activate_db = "<C-a>"
+        activate_db = "<C-a>",
+
+        -- Execute query (just like keybinds.execute_query) while in insert mode for query
+        insert_execute_query = "<C-r>",
     }
 }
 ```
@@ -150,6 +153,8 @@ By default, the keymap to execute commands is set to `<leader>r`, acting differe
     <kdb>&lt;leader>r</kbd> (normal mode): Runs the entire buffer as a query.
     <kdb>&lt;leader>r</kbd> (visual mode): Runs the selected lines as a query. (visual, visual block, and/or visual line)
 </pre>
+
+You can also execute a query while editing it (default: `<C-r>`).
 
 Upon executing a query, the results will be shown in a results buffer.
 

--- a/lua/sqlua/connectors/base.lua
+++ b/lua/sqlua/connectors/base.lua
@@ -411,8 +411,8 @@ function Connection:execute(--[[optional mode string]]mode)
 
     local query = nil
 
-    -- normal mode
-    if mode == "n" then
+    -- normal mode or insert mode (generally comes to us as "ic" but capture other forms as well)
+    if mode == "n" or mode:sub(1, 1) == "i" then
         query = vim.api.nvim_buf_get_lines(0, 0, -1, false)
     -- visual line mode
     elseif mode == "V" then

--- a/lua/sqlua/init.lua
+++ b/lua/sqlua/init.lua
@@ -19,6 +19,7 @@ DEFAULT_CONFIG = {
     keybinds = {
         execute_query = "<leader>r",
         activate_db = "<C-a>",
+        insert_execute_query = "<C-r>",
     },
 }
 


### PR DESCRIPTION
I find it tedious having to exit insert mode to run a query.

An alternative sane default to this could be `nil`, which would stop it from happening.  But I also felt `<C-r>` was a sane/safe editing hotkey for this.